### PR TITLE
Added missing geneplotter package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
 FROM genepi/cloudgene
 
-MAINTAINER Sebastian Schoenherr <sebastian.schoenherr@i-med.ac.at>, Lukas Forer <lukas.forer@i-med.ac.at>
+MAINTAINER Oskar Vidarsson <oskar.vidarsson@uib.no>
+
+# Install dependencies for R packages
+RUN apt update && \
+apt -y install \
+libxml2-dev \
+libcurl4-openssl-dev && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
 
 # Install R Packages
 RUN R -e "install.packages('RColorBrewer', repos = 'http://cran.rstudio.com' )"
-# TODO: ask Seb. needed? works also without package. could ne removed from R report?
-# RUN R -e "install.packages('geneplotter', repos = 'http://cran.rstudio.com' )"
+
+RUN R -e "source('https://bioconductor.org/biocLite.R' )" -e 'biocLite("geneplotter")'
 
 # Add imputationserver specific pages
 ADD pages /opt/cloudgene/sample/pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM genepi/cloudgene
 
-MAINTAINER Oskar Vidarsson <oskar.vidarsson@uib.no>
+MAINTAINER Sebastian Schoenherr <sebastian.schoenherr@i-med.ac.at>, Lukas Forer <lukas.forer@i-med.ac.at>
 
 # Install dependencies for R packages
 RUN apt update && \


### PR DESCRIPTION
I fixed the issue I opened: https://github.com/genepi/imputationserver-docker/issues/2
The issue is that geneplotter isn't available for the currently installed R version when trying to install with the default repository.
To solve it I used the biocLite repository, rebuilt the image and tested it using the https://imputationserver.sph.umich.edu/static/downloads/hapmap300.chr1.recode.vcf.gz test dataset from the docker.md file.
Now the `qcreport.html` file does not complain about a missing geneplotter library anymore.
I hope this helps.
